### PR TITLE
36/라우팅 오류 해결

### DIFF
--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -5,8 +5,8 @@ import mainImage from "../assets/image/mainPageImage.png";
 import styles from "./MainPage.module.css";
 
 const MainPage = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
   // 메인페이지 접속시 토큰을 로그로 출력
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -19,7 +19,7 @@ const MainPage = () => {
 
   return (
     <>
-      <Navbar />
+      <Navbar setIsLoggedIn={setIsLoggedIn}/>
       <div className={styles.container}>
         <img src={mainImage} />  
 

--- a/frontend/src/components/Mypage/Mypage.jsx
+++ b/frontend/src/components/Mypage/Mypage.jsx
@@ -1,18 +1,20 @@
 import React, {useState, useEffect} from "react";
 import Navbar from "../UI/Navbar.jsx";
+import { useNavigate } from "react-router-dom";
 
 const Mypage = () => {
     const [isLoggedIn, setIsLoggedIn] = useState(false);
-    
+    const navigate = useNavigate();
     useEffect(() => {
         const token = localStorage.getItem('token');
         console.log("token : " + token);
         if(token) {
           setIsLoggedIn(true);
         }
-        if(isLoggedIn === false){
+        else{
           navigate('/Login');
         }
+
       }, []);
 
     return (

--- a/frontend/src/components/Plan/NewPlan.jsx
+++ b/frontend/src/components/Plan/NewPlan.jsx
@@ -49,7 +49,7 @@ const NewPlan = () => {
     if(token) {
       setIsLoggedIn(true);
     }
-    if(isLoggedIn === false){
+    else{
       navigate('/Login');
     }
   }, []);

--- a/frontend/src/components/TravelReview/NewReview.jsx
+++ b/frontend/src/components/TravelReview/NewReview.jsx
@@ -24,9 +24,9 @@ const NewReview = () => {
         if(token) {
           setIsLoggedIn(true);
         }
-        if(isLoggedIn === false){
-          navigate('/Login');
-        }
+        else{
+            navigate('/Login');
+          }
       }, []);
 
     const onImageChange = (event) => {

--- a/frontend/src/components/UI/Navbar.jsx
+++ b/frontend/src/components/UI/Navbar.jsx
@@ -4,7 +4,7 @@ import logo from '../../assets/icon.svg';
 import "./Navbar.css";
 
 
-const Navbar = () => {
+const Navbar = (props) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const navigate = useNavigate();
 
@@ -17,8 +17,8 @@ const Navbar = () => {
 
   const logoutHandler = () => {
     localStorage.clear();
-    setIsLoggedIn(false);
-    navigate('/');
+    props.setIsLoggedIn(false);
+
   };
 
   return (
@@ -52,7 +52,7 @@ const Navbar = () => {
         {isLoggedIn ? (
             <Link to="/" style={{textDecorationLine: "none"}}>
               <div className="nav-btn" onClick={logoutHandler}>
-                <button className="navbar-button">Logout</button>
+                <button  className="navbar-button">Logout</button>
               </div>
             </Link>
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #36 

## 📝 작업 요약

로그인 되어 있어도 계획생성, 리뷰작성, 마이페이지로 이동 안되던 오류 해결

## ⏰ 소요 시간
23.11.18 10분


## 🔎 작업 상세 설명

기존에는 토큰의 값이 참이면 isLoggedIn state값이 바뀌면서 state 값에 따라 navigate 시켰는데
토큰의 값이 참이 아니면(else)이면 navigate 시키게 변경해서 해결
로그아웃 버튼 누르면 메인 페이지에 지금 계획하기 버튼 지금 가입하기로 바뀌도록
setIsLoggedIn state를 메인페이지에서 네비게이션바로 props로 전달해서
state 값을 네비게이션 바에서 set해주면 상위 컴포넌트에 state 값이 바뀌므로 메인페이지 컴포넌트가 다시 마운트되게 해서 해결

## 🌟 논의 사항

크루들과 이야기 해보고 싶은 부분을 적어주세요.